### PR TITLE
Fix typo in localStorage call; use correct Array::indexOf method

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,12 +45,12 @@ class Application {
   constructor(canvas) {
     this.#graphics = new Graphics3D(canvas, this.#mouse);
     let selectedFragment = storage.getLocalItem('selectedProgram');
-    const selectionIsValid = selectedFragment in this.#graphics.availableFragments;
+    const selectionIsValid = this.#graphics.availableFragments.indexOf(selectedFragment) >= 0;
     if (!selectedFragment || !selectionIsValid) {
-      storage.setLocalItem('selectdProgram', Application.#defaultProgram);
+      storage.setLocalItem('selectedProgram', Application.#defaultProgram);
       selectedFragment = Application.#defaultProgram;
     }
-    this.#graphics.setFragment(selectedFragment);
+    this.setFragment(selectedFragment);
   }
   
   run() {


### PR DESCRIPTION
- Fix a typo in the `localStorage` call (get the correct key).
- Instead of `a in b`, use `b.indexOf(a) >= 0`.